### PR TITLE
28 - Gramática Regular

### DIFF
--- a/tc/glc.py
+++ b/tc/glc.py
@@ -24,3 +24,45 @@
         conjunto_terminais = [(final,'')]
         aux = set(conjunto_terminais) 
         P.update(conjunto_terminais)
+
+
+# 28 - Gramática Regular
+# Dennis Rodrigues
+def regular(gramatica):
+    producoes = gramatica[2]
+    terminais = gramatica[1]
+    variaveis = gramatica[0]
+
+    regular_direita = False
+    regular_esquerda = False
+
+    for producao in producoes:
+        variavel = 0
+        temp1 = ''
+        temp2 = ''
+
+        if(type(producao[1]) == tuple) and (len(producao[1]) > 0):
+            for i in producao[1]:
+                if i in terminais:
+                    temp1 += str(i)
+                elif i in variaveis:
+                    variavel += 1
+                    temp1 += str(i)
+                    temp2 = str(i)
+                    if variavel > 1:
+                        return 'A gramatica contem mais do que uma variavel como derivacao de uma das producoes, logo nao e regular.'
+            if temp2 in temp1[0]:
+                regular_esquerda = True    
+                continue
+            elif temp2 in temp1[-1]:
+                regular_direita = True
+                continue
+            else:
+                return 'A gramatica nao e regular. Contem uma variavel que nao fica a direita e nem a esquerda.'
+            
+    if regular_esquerda and not regular_direita:
+        return 'A gramatica e regular a esquerda.'
+    elif regular_direita and not regular_esquerda:
+        return 'A gramatica e regular a direita.'
+    else:
+        return 'A gramatica nao e regular.'


### PR DESCRIPTION
Python não aceita listas dentro de conjuntos, então foram utilizadas tuplas no lugar para o corpo de cada produção.